### PR TITLE
Fix list_routes NameError

### DIFF
--- a/airspacesim/cli/commands.py
+++ b/airspacesim/cli/commands.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import argparse
 from importlib import resources
+import json
 
 def copy_file(src, dest):
     """Safely copy a file from package resources to the user's workspace."""


### PR DESCRIPTION
## Summary
- import `json` in CLI commands
- ensure `list_routes` uses the imported module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68871e3729048320ad89aecb31d58a49